### PR TITLE
feat: add ARM64 architecture support for Docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -63,4 +66,4 @@ jobs:
           labels: ${{steps.meta.outputs.labels}}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary
- Add QEMU setup step for cross-architecture emulation in GitHub Actions
- Expand Docker build platforms from `linux/amd64` to `linux/amd64,linux/arm64`

## Changes
- `.github/workflows/docker-build.yml`: Added `docker/setup-qemu-action@v3` step and updated platforms line

## Notes
- Build time will roughly double since each platform builds separately
- Resolves VMC-5: GitHub镜像编译不支持arm架构

🤖 Generated with [Claude Code](https://claude.com/claude-code)